### PR TITLE
Updated manifest with "groups" property

### DIFF
--- a/src/webparts/sampleTargetedComponent/SampleTargetedComponentWebPart.manifest.json
+++ b/src/webparts/sampleTargetedComponent/SampleTargetedComponentWebPart.manifest.json
@@ -21,7 +21,8 @@
     "description": { "default": "Sample Targeted Component description" },
     "officeFabricIconFontName": "Page",
     "properties": {
-      "description": "Sample Targeted Component"
+      "description": "Sample Targeted Component",
+      "groups" : [{"fullName": "My SharePoint Group Members", "login": "My SharePoint Group Members", "id": "5", "description": "My SharePoint Group Members"}]
     }
   }]
 }


### PR DESCRIPTION
I was getting: 'map is not a function' error in TargetAudience.tsx.  This was because there was not default groups array set.
I needed to add a property, "groups"  to the manifest.  I added a placeholder for the "groups" property with a generic groups name which need to be changed to reflect relevant SharePoint groups